### PR TITLE
Add ride share monorepo skeleton

### DIFF
--- a/ride-share-app/README.md
+++ b/ride-share-app/README.md
@@ -1,0 +1,16 @@
+# Ride Share App
+
+Monorepo com backend Node/Express, frontend React e app mobile React Native.
+
+## Variáveis de Ambiente
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `GOOGLE_MAPS_API_KEY`
+
+## Scripts
+- `npm run start:backend`
+- `npm run start:web`
+- `npm run start:mobile`
+- `npm run test:backend`
+- `npm run test:web`
+- `npm run test:mobile`

--- a/ride-share-app/cypress.config.ts
+++ b/ride-share-app/cypress.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'cypress';
+export default defineConfig({
+  e2e: { baseUrl: 'http://localhost:3000' }
+});

--- a/ride-share-app/detox.config.js
+++ b/ride-share-app/detox.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testRunner: 'jest',
+  configurations: {
+    ios: {
+      type: 'ios.simulator',
+      device: { type: 'iPhone 14' }
+    }
+  }
+};

--- a/ride-share-app/jest.config.js
+++ b/ride-share-app/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  projects: ['<rootDir>/packages/backend', '<rootDir>/packages/web', '<rootDir>/packages/mobile']
+};

--- a/ride-share-app/package.json
+++ b/ride-share-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ride-share-app",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "start:backend": "ts-node packages/backend/src/index.ts",
+    "start:web": "vite --config packages/web/vite.config.ts",
+    "start:mobile": "expo start --config packages/mobile/app.json",
+    "test:backend": "jest --config packages/backend/jest.config.js",
+    "test:web": "jest --config packages/web/jest.config.js",
+    "test:mobile": "jest --config packages/mobile/jest.config.js",
+    "test:e2e:web": "cypress run",
+    "test:e2e:mobile": "detox test",
+    "build:backend": "tsc -p packages/backend",
+    "build:web": "vite build --config packages/web/vite.config.ts",
+    "build:mobile": "expo build",
+    "build": "npm run build:backend && npm run build:web && npm run build:mobile"
+  }
+}

--- a/ride-share-app/packages/backend/jest.config.js
+++ b/ride-share-app/packages/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/ride-share-app/packages/backend/package.json
+++ b/ride-share-app/packages/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {"dev": "ts-node src/index.ts"},
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "socket.io": "^4.7.2",
+    "@prisma/client": "^5.9.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "ts-node": "^10.9.1",
+    "prisma": "^5.9.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "supertest": "^6.3.3"
+  }
+}

--- a/ride-share-app/packages/backend/prisma/schema.prisma
+++ b/ride-share-app/packages/backend/prisma/schema.prisma
@@ -1,0 +1,21 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id       Int     @id @default(autoincrement())
+  email    String  @unique
+  password String
+  role     String
+}
+model Ride {
+  id        Int  @id @default(autoincrement())
+  passenger Int
+  driver    Int?
+  status    String
+}

--- a/ride-share-app/packages/backend/src/index.ts
+++ b/ride-share-app/packages/backend/src/index.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(express.json());
+
+app.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user || user.password !== password) return res.status(401).send('Invalid');
+  const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET || 'secret');
+  res.json({ token });
+});
+
+app.get('/rides', async (req, res) => {
+  const rides = await prisma.ride.findMany();
+  res.json(rides);
+});
+
+export default app;
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3001;
+  app.listen(PORT, () => console.log(`Backend on ${PORT}`));
+}

--- a/ride-share-app/packages/backend/tests/basic.test.ts
+++ b/ride-share-app/packages/backend/tests/basic.test.ts
@@ -1,0 +1,7 @@
+import request from 'supertest';
+import app from '../src/index';
+
+test('unauthorized', async () => {
+  const res = await request(app).get('/rides');
+  expect(res.status).toBe(200);
+});

--- a/ride-share-app/packages/backend/tsconfig.json
+++ b/ride-share-app/packages/backend/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {"outDir": "dist", "rootDir": "src"},
+  "include": ["src"]
+}

--- a/ride-share-app/packages/mobile/app.json
+++ b/ride-share-app/packages/mobile/app.json
@@ -1,0 +1,3 @@
+{
+  "expo": {"name": "RideShareMobile", "slug": "rideshare-mobile", "version": "1.0.0"}
+}

--- a/ride-share-app/packages/mobile/jest.config.js
+++ b/ride-share-app/packages/mobile/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom'
+};

--- a/ride-share-app/packages/mobile/package.json
+++ b/ride-share-app/packages/mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mobile",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {"start": "expo start"},
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.73.0",
+    "expo": "^50.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/ride-share-app/packages/mobile/src/App.tsx
+++ b/ride-share-app/packages/mobile/src/App.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+export default function App(){
+  return <View><Text>Mobile</Text></View>;
+}

--- a/ride-share-app/packages/mobile/tests/app.test.tsx
+++ b/ride-share-app/packages/mobile/tests/app.test.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import App from '../src/App';
+import renderer from 'react-test-renderer';
+test('renders', ()=>{ renderer.create(<App />); });

--- a/ride-share-app/packages/mobile/tsconfig.json
+++ b/ride-share-app/packages/mobile/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {"jsx": "react", "outDir": "dist", "rootDir": "src"},
+  "include": ["src"]
+}

--- a/ride-share-app/packages/web/index.html
+++ b/ride-share-app/packages/web/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><div id="root"></div><script type="module" src="/src/main.tsx"></script></body></html>

--- a/ride-share-app/packages/web/jest.config.js
+++ b/ride-share-app/packages/web/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom'
+};

--- a/ride-share-app/packages/web/package.json
+++ b/ride-share-app/packages/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {"dev": "vite", "build": "vite build"},
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "axios": "^1.6.8"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "typescript": "^5.4.0",
+    "tailwindcss": "^3.3.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.2"
+  }
+}

--- a/ride-share-app/packages/web/src/main.tsx
+++ b/ride-share-app/packages/web/src/main.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+function App(){return <h1>Hello</h1>}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App/>);

--- a/ride-share-app/packages/web/tailwind.config.js
+++ b/ride-share-app/packages/web/tailwind.config.js
@@ -1,0 +1,1 @@
+module.exports = {content: ['./src/**/*.{ts,tsx}'], theme: {extend: {}}, plugins: []};

--- a/ride-share-app/packages/web/tests/basic.test.tsx
+++ b/ride-share-app/packages/web/tests/basic.test.tsx
@@ -1,0 +1,3 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import App from '../src/main';

--- a/ride-share-app/packages/web/tsconfig.json
+++ b/ride-share-app/packages/web/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {"jsx": "react-jsx", "outDir": "dist", "rootDir": "src"},
+  "include": ["src"]
+}

--- a/ride-share-app/packages/web/vite.config.ts
+++ b/ride-share-app/packages/web/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+export default defineConfig({ plugins: [react()] });

--- a/ride-share-app/tsconfig.json
+++ b/ride-share-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "packages",
+    "strict": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add `ride-share-app` monorepo with workspaces
- skeleton backend with Express and Prisma
- skeleton web frontend with React and Vite
- skeleton mobile app using Expo
- include basic project configs

## Testing
- `npm run test:backend` *(fails: jest not found)*
- `npm run test:web` *(fails: jest not found)*
- `npm run test:mobile` *(fails: jest not found)*
- `npm run test:e2e:web` *(fails: cypress not found)*
- `npm run test:e2e:mobile` *(fails: detox not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fcf0b66e0832393e29a70ece67a57